### PR TITLE
Fix for 'unary operator expected'

### DIFF
--- a/twirl
+++ b/twirl
@@ -546,7 +546,7 @@ gem_install_or_update() {
 }
 
 install_brews() {
-    if test ! $(brew list | grep $brew); then
+    if test ! $(brew list | grep $brew | head -n 1); then
         echo_install "Installing $brew"
 		brew install $brew >/dev/null
 		print_in_green "${bold}✓ installed!${normal}\n"


### PR DESCRIPTION
If there is more than one brew returned in a search, you get the error `unary operator expected`

For example:

* You install `git` and `git-lfs`
* Next run, twirl runs `brew list | grep git`
* That returns
```
git
git-lfs
```
* `test` throws `unary operator expected`

This PR fixes that